### PR TITLE
feat: support PublicAccess decorator on controllers

### DIFF
--- a/examples/express-backend/src/app.module.ts
+++ b/examples/express-backend/src/app.module.ts
@@ -6,6 +6,7 @@ import { AppController } from './app.controller'
 import { SuperTokensModule, SuperTokensAuthGuard } from 'supertokens-nestjs'
 
 import { appInfo, connectionURI, recipeList } from './config'
+import { HealthController } from './health.controller'
 
 @Module({
   imports: [
@@ -19,7 +20,7 @@ import { appInfo, connectionURI, recipeList } from './config'
       recipeList,
     }),
   ],
-  controllers: [AppController],
+  controllers: [AppController, HealthController],
   providers: [
     {
       provide: APP_GUARD,

--- a/examples/express-backend/src/health.controller.ts
+++ b/examples/express-backend/src/health.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common'
+import { PublicAccess } from 'supertokens-nestjs'
+
+@PublicAccess()
+@Controller()
+export class HealthController {
+  @Get('/healthz')
+  healthCheck() {
+    return { status: 'ok', message: 'Healthy!' }
+  }
+}

--- a/src/supertokens-auth.guard.ts
+++ b/src/supertokens-auth.guard.ts
@@ -21,9 +21,9 @@ export class SuperTokensAuthGuard implements CanActivate {
   private reflector: Reflector
   private customCtxDataExtractor?: ContextDataExtractor
 
-  constructor(@Optional() extractDataFromConext?: ContextDataExtractor) {
+  constructor(@Optional() extractDataFromContext?: ContextDataExtractor) {
     this.reflector = new Reflector()
-    this.customCtxDataExtractor = extractDataFromConext
+    this.customCtxDataExtractor = extractDataFromContext
   }
 
   public async canActivate(context: ExecutionContext): Promise<boolean> {

--- a/src/supertokens-auth.guard.ts
+++ b/src/supertokens-auth.guard.ts
@@ -27,7 +27,7 @@ export class SuperTokensAuthGuard implements CanActivate {
   }
 
   public async canActivate(context: ExecutionContext): Promise<boolean> {
-    const isPublic = this.reflector.getAllAndOverride<boolean>(PublicAccess, [
+    const isPublic = this.reflector.getAllAndOverride(PublicAccess, [
       context.getHandler(),
       context.getClass(),
     ])

--- a/src/supertokens-auth.guard.ts
+++ b/src/supertokens-auth.guard.ts
@@ -27,7 +27,10 @@ export class SuperTokensAuthGuard implements CanActivate {
   }
 
   public async canActivate(context: ExecutionContext): Promise<boolean> {
-    const isPublic = this.reflector.get(PublicAccess, context.getHandler())
+    const isPublic = this.reflector.getAllAndOverride<boolean>(PublicAccess, [
+      context.getHandler(),
+      context.getClass(),
+    ])
 
     if (isPublic) return true
 


### PR DESCRIPTION
### Improvements
- This PR adds support for applying the `PublicAccess` decorator at the controller level, making all routes within the decorated controller publicly accessible. Tests have been updated to verify that both controller-level and handler-level usage of PublicAccess work as expected.
- Includes a typo fix on the guad class member `extractDataFromContext`
- Includes an updated example of `PublicAccess` applied on a `HealthController` in the express application 

This improvement closes #19 
