### PR TITLE
Expose composable session verifier

### DIFF
--- a/.changeset/tender-mice-occur.md
+++ b/.changeset/tender-mice-occur.md
@@ -1,0 +1,5 @@
+---
+'supertokens-nestjs': minor
+---
+
+Expose `SuperTokensSessionVerifier` so custom guards can compose multiple verifier methods while reusing SuperTokens session validation instead of duplicating `VerifySession` logic.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ export class AppController {}
 ### 4. Add the CORS config and the exception filter in your `bootstrap` function
 
 For Express:
+
 ```ts
 import supertokens from 'supertokens-node'
 import { SuperTokensExceptionFilter } from 'supertokens-nestjs'
@@ -112,7 +113,6 @@ async function bootstrap() {
 ```
 
 For Fastify, use `SuperTokensFastifyExceptionFilter` instead of `SuperTokensExceptionFilter`.
-
 
 ### 5. Use the provided decorators to customize the route protection logic and access the authentication state
 
@@ -135,5 +135,49 @@ class AppController {
   @Get('/user/profile')
   @PublicAccess()
   async getUserProfile() {}
+}
+```
+
+### 6. Compose session verification in custom guards
+
+Use `SuperTokensSessionVerifier` when you need a custom guard that composes SuperTokens session verification with another authentication strategy.
+
+This is useful for routes that can accept more than one credential type, such as an API key or a SuperTokens session.
+The custom guard can decide which credential to validate while still reusing the same `VerifySession` logic as `SuperTokensAuthGuard`, including roles, permissions, MFA, email verification, and custom `VerifySessionOptions`.
+
+```ts
+import {
+  CanActivate,
+  Controller,
+  ExecutionContext,
+  Get,
+  Injectable,
+  UseGuards,
+} from '@nestjs/common'
+import { SuperTokensSessionVerifier, VerifySession } from 'supertokens-nestjs'
+
+@Injectable()
+class ApiKeyOrSessionGuard implements CanActivate {
+  constructor(private readonly sessionVerifier: SuperTokensSessionVerifier) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const apiKey = getApiKey(context)
+    if (apiKey) {
+      // Validate your application-specific API key here.
+      return verifyApiKey(apiKey)
+    }
+
+    return this.sessionVerifier.verifySession(context)
+  }
+}
+
+@Controller()
+class AppController {
+  @Get('/admin')
+  @VerifySession({
+    permissions: ['admin:read'],
+  })
+  @UseGuards(ApiKeyOrSessionGuard)
+  async getAdminData() {}
 }
 ```

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -3,4 +3,5 @@ export { SuperTokensExpressExceptionFilter, SuperTokensExpressExceptionFilter as
 export * from './supertokens-fastify-exception.filter';
 export * from './supertokens-auth.guard';
 export * from './supertokens-session.verifier';
+export type { ContextDataExtractor, SuperTokensModuleAsyncOptions, SuperTokensModuleOptions, SuperTokensModuleOptionsFactory, SuperTokensSession, VerifySessionDecoratorOptions, } from './supertokens.types';
 export * from './decorators';

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -2,4 +2,5 @@ export * from './supertokens.module';
 export { SuperTokensExpressExceptionFilter, SuperTokensExpressExceptionFilter as SuperTokensExceptionFilter, } from './supertokens-express-exception.filter';
 export * from './supertokens-fastify-exception.filter';
 export * from './supertokens-auth.guard';
+export * from './supertokens-session.verifier';
 export * from './decorators';

--- a/dist/index.js
+++ b/dist/index.js
@@ -21,4 +21,5 @@ Object.defineProperty(exports, "SuperTokensExpressExceptionFilter", { enumerable
 Object.defineProperty(exports, "SuperTokensExceptionFilter", { enumerable: true, get: function () { return supertokens_express_exception_filter_1.SuperTokensExpressExceptionFilter; } });
 __exportStar(require("./supertokens-fastify-exception.filter"), exports);
 __exportStar(require("./supertokens-auth.guard"), exports);
+__exportStar(require("./supertokens-session.verifier"), exports);
 __exportStar(require("./decorators"), exports);

--- a/dist/supertokens-auth.guard.d.ts
+++ b/dist/supertokens-auth.guard.d.ts
@@ -1,10 +1,9 @@
 import { CanActivate, ExecutionContext } from '@nestjs/common';
 import { ContextDataExtractor } from './supertokens.types';
+import { SuperTokensSessionVerifier } from './supertokens-session.verifier';
 export declare class SuperTokensAuthGuard implements CanActivate {
-    private reflector;
-    private customCtxDataExtractor?;
+    private readonly sessionVerifier;
     constructor(extractDataFromContext?: ContextDataExtractor);
+    constructor(sessionVerifier?: SuperTokensSessionVerifier, extractDataFromContext?: ContextDataExtractor);
     canActivate(context: ExecutionContext): Promise<boolean>;
-    private extractDataFromContext;
-    private getVerifySessionOptions;
 }

--- a/dist/supertokens-auth.guard.js
+++ b/dist/supertokens-auth.guard.js
@@ -11,97 +11,30 @@ var __metadata = (this && this.__metadata) || function (k, v) {
 var __param = (this && this.__param) || function (paramIndex, decorator) {
     return function (target, key) { decorator(target, key, paramIndex); }
 };
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.SuperTokensAuthGuard = void 0;
 const common_1 = require("@nestjs/common");
-const core_1 = require("@nestjs/core");
-const userroles_1 = __importDefault(require("supertokens-node/recipe/userroles"));
-const session_1 = require("supertokens-node/recipe/session");
-const emailverification_1 = require("supertokens-node/recipe/emailverification");
-const multifactorauth_1 = require("supertokens-node/recipe/multifactorauth");
-const decorators_1 = require("./decorators");
+const supertokens_session_verifier_1 = require("./supertokens-session.verifier");
 let SuperTokensAuthGuard = class SuperTokensAuthGuard {
-    constructor(extractDataFromContext) {
-        this.reflector = new core_1.Reflector();
-        this.customCtxDataExtractor = extractDataFromContext;
+    constructor(sessionVerifierOrExtractDataFromContext, extractDataFromContext) {
+        if (typeof sessionVerifierOrExtractDataFromContext === 'function') {
+            this.sessionVerifier = new supertokens_session_verifier_1.SuperTokensSessionVerifier(sessionVerifierOrExtractDataFromContext);
+            return;
+        }
+        this.sessionVerifier =
+            sessionVerifierOrExtractDataFromContext ??
+                new supertokens_session_verifier_1.SuperTokensSessionVerifier(extractDataFromContext);
     }
     async canActivate(context) {
-        const isPublic = this.reflector.getAllAndOverride(decorators_1.PublicAccess, [
-            context.getHandler(),
-            context.getClass(),
-        ]);
-        if (isPublic)
+        if (this.sessionVerifier.isPublic(context))
             return true;
-        const { request, response } = this.extractDataFromContext(context);
-        const verifySessionOptions = this.getVerifySessionOptions(context);
-        const session = await (0, session_1.getSession)(request, response, verifySessionOptions);
-        request.session = session;
-        return true;
-    }
-    extractDataFromContext(context) {
-        if (this.customCtxDataExtractor) {
-            return this.customCtxDataExtractor(context);
-        }
-        const ctx = context.switchToHttp();
-        const request = ctx.getRequest();
-        const response = ctx.getResponse();
-        return { request, response };
-    }
-    getVerifySessionOptions(context) {
-        const verifySessionDecoratorOptions = this.reflector.get(decorators_1.VerifySession, context.getHandler());
-        const { roles, permissions, requireEmailVerification, requireMFA, options: verifySessionOptions, } = verifySessionDecoratorOptions || {};
-        const extraClaimValidators = [];
-        const validatorsToRemove = [];
-        if (roles) {
-            extraClaimValidators.push(userroles_1.default.UserRoleClaim.validators.includesAll(roles));
-        }
-        if (permissions) {
-            extraClaimValidators.push(userroles_1.default.PermissionClaim.validators.includesAll(permissions));
-        }
-        if (requireEmailVerification) {
-            extraClaimValidators.push(emailverification_1.EmailVerificationClaim.validators.isVerified());
-        }
-        else if (requireEmailVerification === false) {
-            validatorsToRemove.push(emailverification_1.EmailVerificationClaim.key);
-        }
-        if (requireMFA) {
-            extraClaimValidators.push(multifactorauth_1.MultiFactorAuthClaim.validators.hasCompletedMFARequirementsForAuth());
-        }
-        else if (requireMFA === false) {
-            validatorsToRemove.push(multifactorauth_1.MultiFactorAuthClaim.key);
-        }
-        const overrideGlobalClaimValidators = async (globalValidators) => {
-            let parsedValidators = [...globalValidators];
-            if (validatorsToRemove.length) {
-                parsedValidators = parsedValidators.filter((validator) => !validatorsToRemove.includes(validator.id));
-            }
-            return [...parsedValidators, ...extraClaimValidators];
-        };
-        if (!verifySessionOptions) {
-            return {
-                overrideGlobalClaimValidators,
-            };
-        }
-        if (verifySessionOptions.overrideGlobalClaimValidators) {
-            return {
-                overrideGlobalClaimValidators: async (globalValidators, session, userContext) => {
-                    const baseValidators = await verifySessionOptions.overrideGlobalClaimValidators(globalValidators, session, userContext);
-                    return overrideGlobalClaimValidators(baseValidators);
-                },
-            };
-        }
-        return {
-            ...verifySessionOptions,
-            overrideGlobalClaimValidators,
-        };
+        return this.sessionVerifier.verifySession(context);
     }
 };
 exports.SuperTokensAuthGuard = SuperTokensAuthGuard;
 exports.SuperTokensAuthGuard = SuperTokensAuthGuard = __decorate([
     (0, common_1.Injectable)(),
     __param(0, (0, common_1.Optional)()),
-    __metadata("design:paramtypes", [Function])
+    __param(0, (0, common_1.Inject)(supertokens_session_verifier_1.SuperTokensSessionVerifier)),
+    __metadata("design:paramtypes", [Object, Function])
 ], SuperTokensAuthGuard);

--- a/dist/supertokens-auth.guard.test.js
+++ b/dist/supertokens-auth.guard.test.js
@@ -30,6 +30,7 @@ const supertokens_node_1 = require("supertokens-node");
 const graphql_2 = require("graphql");
 const supertokens_module_1 = require("./supertokens.module");
 const supertokens_auth_guard_1 = require("./supertokens-auth.guard");
+const supertokens_session_verifier_1 = require("./supertokens-session.verifier");
 const supertokens_express_exception_filter_1 = require("./supertokens-express-exception.filter");
 const core_1 = require("@nestjs/core");
 const decorators_1 = require("./decorators");
@@ -195,9 +196,24 @@ vitest_1.vi.mock('supertokens-node/recipe/session', { spy: true });
     });
     (0, vitest_1.describe)('Decorators', async () => {
         let app;
-        let guard;
+        let sessionVerifier;
         let checkSessionDecoratorFn = vitest_1.vi.fn();
+        let checkComposedGuardFn = vitest_1.vi.fn();
         (0, vitest_1.beforeAll)(async () => {
+            let ComposedAuthGuard = class ComposedAuthGuard {
+                constructor(verifier) {
+                    this.verifier = verifier;
+                }
+                async canActivate(context) {
+                    checkComposedGuardFn(this.verifier.isPublic(context));
+                    return this.verifier.verifySession(context);
+                }
+            };
+            ComposedAuthGuard = __decorate([
+                (0, common_1.Injectable)(),
+                __param(0, (0, common_1.Inject)(supertokens_session_verifier_1.SuperTokensSessionVerifier)),
+                __metadata("design:paramtypes", [supertokens_session_verifier_1.SuperTokensSessionVerifier])
+            ], ComposedAuthGuard);
             let TestController = class TestController {
                 getPublic() { }
                 getProtected() { }
@@ -334,6 +350,22 @@ vitest_1.vi.mock('supertokens-node/recipe/session', { spy: true });
                 (0, common_1.Controller)(),
                 (0, common_1.UseGuards)(supertokens_auth_guard_1.SuperTokensAuthGuard)
             ], TestController);
+            let ComposedController = class ComposedController {
+                composed() { }
+            };
+            __decorate([
+                (0, decorators_1.VerifySession)({
+                    permissions: ['compose'],
+                }),
+                (0, common_1.UseGuards)(ComposedAuthGuard),
+                (0, common_1.Get)('/'),
+                __metadata("design:type", Function),
+                __metadata("design:paramtypes", []),
+                __metadata("design:returntype", void 0)
+            ], ComposedController.prototype, "composed", null);
+            ComposedController = __decorate([
+                (0, common_1.Controller)('/composed')
+            ], ComposedController);
             const moduleRef = await testing_1.Test.createTestingModule({
                 imports: [
                     supertokens_module_1.SuperTokensModule.forRoot({
@@ -345,10 +377,11 @@ vitest_1.vi.mock('supertokens-node/recipe/session', { spy: true });
                         recipeList: [session_1.default.init(), emailpassword_1.default.init()],
                     }),
                 ],
-                controllers: [TestController],
+                controllers: [TestController, ComposedController],
+                providers: [ComposedAuthGuard],
             }).compile();
             app = moduleRef.createNestApplication();
-            guard = moduleRef.get(supertokens_auth_guard_1.SuperTokensAuthGuard);
+            sessionVerifier = moduleRef.get(supertokens_session_verifier_1.SuperTokensSessionVerifier);
             app.useGlobalFilters(new supertokens_express_exception_filter_1.SuperTokensExpressExceptionFilter());
             await app.init();
             await app.listen(0);
@@ -360,6 +393,7 @@ vitest_1.vi.mock('supertokens-node/recipe/session', { spy: true });
         });
         (0, vitest_1.beforeEach)(async () => {
             getSession.mockClear();
+            checkComposedGuardFn.mockClear();
         });
         (0, vitest_1.it)('PublicAccess', async () => {
             await (0, supertest_1.default)(app.getHttpServer()).get(`/`).expect(200);
@@ -424,6 +458,20 @@ vitest_1.vi.mock('supertokens-node/recipe/session', { spy: true });
             (0, vitest_1.expect)(getSession).toHaveBeenCalledTimes(2);
             const [, , customVerifySessionOptions] = getSession.mock.lastCall;
             (0, vitest_1.expect)(customVerifySessionOptions.checkDatabase).toBeTruthy();
+        });
+        (0, vitest_1.it)('exposes reusable session verifier', async () => {
+            (0, vitest_1.expect)(sessionVerifier).toBeInstanceOf(supertokens_session_verifier_1.SuperTokensSessionVerifier);
+        });
+        (0, vitest_1.it)('supports composed guards that validate sessions with VerifySession metadata', async () => {
+            getSession.mockImplementationOnce(() => ({ getUserId: () => 'userId' }));
+            await (0, supertest_1.default)(app.getHttpServer()).get(`/composed/`).expect(200);
+            (0, vitest_1.expect)(checkComposedGuardFn).toHaveBeenCalledWith(false);
+            (0, vitest_1.expect)(getSession).toHaveBeenCalledTimes(1);
+            const [, , verifySessionOptions] = getSession.mock.lastCall;
+            const actualValidators = await verifySessionOptions.overrideGlobalClaimValidators([]);
+            const expectedValidator = userroles_1.default.PermissionClaim.validators.includesAll(['compose']);
+            const ids = actualValidators.map((validator) => validator.id);
+            (0, vitest_1.expect)(ids).toContain(expectedValidator.id);
         });
         (0, vitest_1.it)('Auth[roles]', async () => {
             await (0, supertest_1.default)(app.getHttpServer()).get(`/roles`);

--- a/dist/supertokens-session.verifier.d.ts
+++ b/dist/supertokens-session.verifier.d.ts
@@ -1,0 +1,15 @@
+import { ExecutionContext } from '@nestjs/common';
+import { VerifySessionOptions } from 'supertokens-node/recipe/session';
+import { ContextDataExtractor } from './supertokens.types';
+export declare class SuperTokensSessionVerifier {
+    private readonly customCtxDataExtractor?;
+    private readonly reflector;
+    constructor(customCtxDataExtractor?: ContextDataExtractor);
+    isPublic(context: ExecutionContext): boolean;
+    verifySession(context: ExecutionContext): Promise<boolean>;
+    extractDataFromContext(context: ExecutionContext): {
+        request: any;
+        response: any;
+    };
+    getVerifySessionOptions(context: ExecutionContext): VerifySessionOptions | undefined;
+}

--- a/dist/supertokens-session.verifier.js
+++ b/dist/supertokens-session.verifier.js
@@ -1,0 +1,107 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __param = (this && this.__param) || function (paramIndex, decorator) {
+    return function (target, key) { decorator(target, key, paramIndex); }
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.SuperTokensSessionVerifier = void 0;
+const common_1 = require("@nestjs/common");
+const core_1 = require("@nestjs/core");
+const emailverification_1 = require("supertokens-node/recipe/emailverification");
+const multifactorauth_1 = require("supertokens-node/recipe/multifactorauth");
+const session_1 = require("supertokens-node/recipe/session");
+const userroles_1 = __importDefault(require("supertokens-node/recipe/userroles"));
+const decorators_1 = require("./decorators");
+let SuperTokensSessionVerifier = class SuperTokensSessionVerifier {
+    constructor(customCtxDataExtractor) {
+        this.customCtxDataExtractor = customCtxDataExtractor;
+        this.reflector = new core_1.Reflector();
+    }
+    isPublic(context) {
+        return Boolean(this.reflector.getAllAndOverride(decorators_1.PublicAccess, [
+            context.getHandler(),
+            context.getClass(),
+        ]));
+    }
+    async verifySession(context) {
+        const { request, response } = this.extractDataFromContext(context);
+        const verifySessionOptions = this.getVerifySessionOptions(context);
+        const session = await (0, session_1.getSession)(request, response, verifySessionOptions);
+        request.session = session;
+        return true;
+    }
+    extractDataFromContext(context) {
+        if (this.customCtxDataExtractor) {
+            return this.customCtxDataExtractor(context);
+        }
+        const ctx = context.switchToHttp();
+        const request = ctx.getRequest();
+        const response = ctx.getResponse();
+        return { request, response };
+    }
+    getVerifySessionOptions(context) {
+        const verifySessionDecoratorOptions = this.reflector.get(decorators_1.VerifySession, context.getHandler());
+        const { roles, permissions, requireEmailVerification, requireMFA, options: verifySessionOptions, } = verifySessionDecoratorOptions || {};
+        const extraClaimValidators = [];
+        const validatorsToRemove = [];
+        if (roles) {
+            extraClaimValidators.push(userroles_1.default.UserRoleClaim.validators.includesAll(roles));
+        }
+        if (permissions) {
+            extraClaimValidators.push(userroles_1.default.PermissionClaim.validators.includesAll(permissions));
+        }
+        if (requireEmailVerification) {
+            extraClaimValidators.push(emailverification_1.EmailVerificationClaim.validators.isVerified());
+        }
+        else if (requireEmailVerification === false) {
+            validatorsToRemove.push(emailverification_1.EmailVerificationClaim.key);
+        }
+        if (requireMFA) {
+            extraClaimValidators.push(multifactorauth_1.MultiFactorAuthClaim.validators.hasCompletedMFARequirementsForAuth());
+        }
+        else if (requireMFA === false) {
+            validatorsToRemove.push(multifactorauth_1.MultiFactorAuthClaim.key);
+        }
+        const overrideGlobalClaimValidators = async (globalValidators) => {
+            let parsedValidators = [...globalValidators];
+            if (validatorsToRemove.length) {
+                parsedValidators = parsedValidators.filter((validator) => !validatorsToRemove.includes(validator.id));
+            }
+            return [...parsedValidators, ...extraClaimValidators];
+        };
+        if (!verifySessionOptions) {
+            return {
+                overrideGlobalClaimValidators,
+            };
+        }
+        if (verifySessionOptions.overrideGlobalClaimValidators) {
+            return {
+                overrideGlobalClaimValidators: async (globalValidators, session, userContext) => {
+                    const baseValidators = await verifySessionOptions.overrideGlobalClaimValidators(globalValidators, session, userContext);
+                    return overrideGlobalClaimValidators(baseValidators);
+                },
+            };
+        }
+        return {
+            ...verifySessionOptions,
+            overrideGlobalClaimValidators,
+        };
+    }
+};
+exports.SuperTokensSessionVerifier = SuperTokensSessionVerifier;
+exports.SuperTokensSessionVerifier = SuperTokensSessionVerifier = __decorate([
+    (0, common_1.Injectable)(),
+    __param(0, (0, common_1.Optional)()),
+    __metadata("design:paramtypes", [Function])
+], SuperTokensSessionVerifier);

--- a/dist/supertokens.module.d.ts
+++ b/dist/supertokens.module.d.ts
@@ -1,5 +1,5 @@
-import { MiddlewareConsumer, DynamicModule } from "@nestjs/common";
-import { SuperTokensModuleOptions, SuperTokensModuleAsyncOptions } from "./supertokens.types";
+import { MiddlewareConsumer, DynamicModule } from '@nestjs/common';
+import { SuperTokensModuleOptions, SuperTokensModuleAsyncOptions } from './supertokens.types';
 export declare class SuperTokensModule {
     private options;
     constructor(options: SuperTokensModuleOptions);

--- a/dist/supertokens.module.js
+++ b/dist/supertokens.module.js
@@ -18,14 +18,15 @@ const common_1 = require("@nestjs/common");
 const supertokens_express_middleware_1 = require("./supertokens-express.middleware");
 const supertokens_constants_1 = require("./supertokens.constants");
 const supertokens_service_1 = require("./supertokens.service");
+const supertokens_session_verifier_1 = require("./supertokens-session.verifier");
 let SuperTokensModule = SuperTokensModule_1 = class SuperTokensModule {
     constructor(options) {
         this.options = options;
     }
     configure(consumer) {
-        if (this.options.framework !== "express")
+        if (this.options.framework !== 'express')
             return;
-        consumer.apply(supertokens_express_middleware_1.SuperTokensExpressAuthMiddleware).forRoutes("*");
+        consumer.apply(supertokens_express_middleware_1.SuperTokensExpressAuthMiddleware).forRoutes('*');
     }
     static forRoot(options) {
         const { global = true } = options;
@@ -38,7 +39,9 @@ let SuperTokensModule = SuperTokensModule_1 = class SuperTokensModule {
                     provide: supertokens_constants_1.SUPERTOKENS_MODULE_OPTIONS,
                 },
                 supertokens_service_1.SuperTokensService,
+                supertokens_session_verifier_1.SuperTokensSessionVerifier,
             ],
+            exports: [supertokens_session_verifier_1.SuperTokensSessionVerifier],
         };
     }
     static forRootAsync(options) {
@@ -47,7 +50,11 @@ let SuperTokensModule = SuperTokensModule_1 = class SuperTokensModule {
             module: SuperTokensModule_1,
             global,
             imports: options.imports || [],
-            providers: [...this.createAsyncProviders(options)],
+            providers: [
+                ...this.createAsyncProviders(options),
+                supertokens_session_verifier_1.SuperTokensSessionVerifier,
+            ],
+            exports: [supertokens_session_verifier_1.SuperTokensSessionVerifier],
         };
     }
     static createAsyncProviders(options) {
@@ -63,7 +70,7 @@ let SuperTokensModule = SuperTokensModule_1 = class SuperTokensModule {
                 },
             ];
         }
-        throw new Error("Invalid configuration options");
+        throw new Error('Invalid configuration options');
     }
     static createAsyncOptionsProvider(options) {
         if (options.useFactory) {
@@ -80,14 +87,14 @@ let SuperTokensModule = SuperTokensModule_1 = class SuperTokensModule {
                 inject: [options.useExisting],
             };
         }
-        throw new Error("Invalid configuration options");
+        throw new Error('Invalid configuration options');
     }
 };
 exports.SuperTokensModule = SuperTokensModule;
 exports.SuperTokensModule = SuperTokensModule = SuperTokensModule_1 = __decorate([
     (0, common_1.Module)({
-        providers: [supertokens_service_1.SuperTokensService],
-        exports: [],
+        providers: [supertokens_service_1.SuperTokensService, supertokens_session_verifier_1.SuperTokensSessionVerifier],
+        exports: [supertokens_session_verifier_1.SuperTokensSessionVerifier],
         controllers: [],
     }),
     __param(0, (0, common_1.Inject)(supertokens_constants_1.SUPERTOKENS_MODULE_OPTIONS)),

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,12 @@ export {
 export * from './supertokens-fastify-exception.filter'
 export * from './supertokens-auth.guard'
 export * from './supertokens-session.verifier'
+export type {
+  ContextDataExtractor,
+  SuperTokensModuleAsyncOptions,
+  SuperTokensModuleOptions,
+  SuperTokensModuleOptionsFactory,
+  SuperTokensSession,
+  VerifySessionDecoratorOptions,
+} from './supertokens.types'
 export * from './decorators'

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,4 +5,5 @@ export {
 } from './supertokens-express-exception.filter'
 export * from './supertokens-fastify-exception.filter'
 export * from './supertokens-auth.guard'
+export * from './supertokens-session.verifier'
 export * from './decorators'

--- a/src/supertokens-auth.guard.test.ts
+++ b/src/supertokens-auth.guard.test.ts
@@ -10,11 +10,14 @@ import {
 } from 'vitest'
 import {
   ArgumentsHost,
+  CanActivate,
   Catch,
   Controller,
   ExceptionFilter,
   ExecutionContext,
   Get,
+  Inject,
+  Injectable,
   INestApplication,
   UseGuards,
 } from '@nestjs/common'
@@ -38,6 +41,7 @@ import { GraphQLError } from 'graphql'
 
 import { SuperTokensModule } from './supertokens.module'
 import { SuperTokensAuthGuard } from './supertokens-auth.guard'
+import { SuperTokensSessionVerifier } from './supertokens-session.verifier'
 import { SuperTokensExpressExceptionFilter } from './supertokens-express-exception.filter'
 import { APP_GUARD } from '@nestjs/core'
 import {
@@ -192,10 +196,24 @@ describe('SuperTokensAuthGuard', () => {
 
   describe('Decorators', async () => {
     let app: INestApplication
-    let guard: SuperTokensAuthGuard
+    let sessionVerifier: SuperTokensSessionVerifier
     let checkSessionDecoratorFn = vi.fn()
+    let checkComposedGuardFn = vi.fn()
 
     beforeAll(async () => {
+      @Injectable()
+      class ComposedAuthGuard implements CanActivate {
+        constructor(
+          @Inject(SuperTokensSessionVerifier)
+          private readonly verifier: SuperTokensSessionVerifier,
+        ) {}
+
+        async canActivate(context: ExecutionContext): Promise<boolean> {
+          checkComposedGuardFn(this.verifier.isPublic(context))
+          return this.verifier.verifySession(context)
+        }
+      }
+
       @Controller()
       @UseGuards(SuperTokensAuthGuard)
       class TestController {
@@ -282,6 +300,16 @@ describe('SuperTokensAuthGuard', () => {
         }
       }
 
+      @Controller('/composed')
+      class ComposedController {
+        @VerifySession({
+          permissions: ['compose'],
+        })
+        @UseGuards(ComposedAuthGuard)
+        @Get('/')
+        composed() {}
+      }
+
       const moduleRef = await Test.createTestingModule({
         imports: [
           SuperTokensModule.forRoot({
@@ -293,11 +321,12 @@ describe('SuperTokensAuthGuard', () => {
             recipeList: [Session.init(), EmailPassword.init()],
           }),
         ],
-        controllers: [TestController],
+        controllers: [TestController, ComposedController],
+        providers: [ComposedAuthGuard],
       }).compile()
 
       app = moduleRef.createNestApplication()
-      guard = moduleRef.get(SuperTokensAuthGuard)
+      sessionVerifier = moduleRef.get(SuperTokensSessionVerifier)
 
       app.useGlobalFilters(new SuperTokensExpressExceptionFilter())
       await app.init()
@@ -313,6 +342,7 @@ describe('SuperTokensAuthGuard', () => {
 
     beforeEach(async () => {
       getSession.mockClear()
+      checkComposedGuardFn.mockClear()
     })
 
     it('PublicAccess', async () => {
@@ -372,6 +402,25 @@ describe('SuperTokensAuthGuard', () => {
       expect(getSession).toHaveBeenCalledTimes(2)
       const [, , customVerifySessionOptions] = getSession.mock.lastCall
       expect(customVerifySessionOptions.checkDatabase).toBeTruthy()
+    })
+    it('exposes reusable session verifier', async () => {
+      expect(sessionVerifier).toBeInstanceOf(SuperTokensSessionVerifier)
+    })
+    it('supports composed guards that validate sessions with VerifySession metadata', async () => {
+      getSession.mockImplementationOnce(() => ({ getUserId: () => 'userId' }))
+
+      await request(app.getHttpServer()).get(`/composed/`).expect(200)
+
+      expect(checkComposedGuardFn).toHaveBeenCalledWith(false)
+      expect(getSession).toHaveBeenCalledTimes(1)
+      const [, , verifySessionOptions] = getSession.mock.lastCall
+      const actualValidators =
+        await verifySessionOptions.overrideGlobalClaimValidators([])
+      const expectedValidator =
+        UserRoles.PermissionClaim.validators.includesAll(['compose'])
+      const ids = actualValidators.map((validator) => validator.id)
+
+      expect(ids).toContain(expectedValidator.id)
     })
     it('Auth[roles]', async () => {
       await request(app.getHttpServer()).get(`/roles`)

--- a/src/supertokens-auth.guard.ts
+++ b/src/supertokens-auth.guard.ts
@@ -1,144 +1,45 @@
 import {
   CanActivate,
   ExecutionContext,
+  Inject,
   Injectable,
   Optional,
 } from '@nestjs/common'
-import { Reflector } from '@nestjs/core'
-import UserRoles from 'supertokens-node/recipe/userroles'
-import {
-  getSession,
-  SessionClaimValidator,
-  VerifySessionOptions,
-} from 'supertokens-node/recipe/session'
-import { EmailVerificationClaim } from 'supertokens-node/recipe/emailverification'
-import { MultiFactorAuthClaim } from 'supertokens-node/recipe/multifactorauth'
-import { VerifySession, PublicAccess } from './decorators'
 import { ContextDataExtractor } from './supertokens.types'
+import { SuperTokensSessionVerifier } from './supertokens-session.verifier'
 
 @Injectable()
 export class SuperTokensAuthGuard implements CanActivate {
-  private reflector: Reflector
-  private customCtxDataExtractor?: ContextDataExtractor
+  private readonly sessionVerifier: SuperTokensSessionVerifier
 
-  constructor(@Optional() extractDataFromContext?: ContextDataExtractor) {
-    this.reflector = new Reflector()
-    this.customCtxDataExtractor = extractDataFromContext
+  constructor(extractDataFromContext?: ContextDataExtractor)
+  constructor(
+    sessionVerifier?: SuperTokensSessionVerifier,
+    extractDataFromContext?: ContextDataExtractor,
+  )
+  constructor(
+    @Optional()
+    @Inject(SuperTokensSessionVerifier)
+    sessionVerifierOrExtractDataFromContext?:
+      | SuperTokensSessionVerifier
+      | ContextDataExtractor,
+    extractDataFromContext?: ContextDataExtractor,
+  ) {
+    if (typeof sessionVerifierOrExtractDataFromContext === 'function') {
+      this.sessionVerifier = new SuperTokensSessionVerifier(
+        sessionVerifierOrExtractDataFromContext,
+      )
+      return
+    }
+
+    this.sessionVerifier =
+      sessionVerifierOrExtractDataFromContext ??
+      new SuperTokensSessionVerifier(extractDataFromContext)
   }
 
   public async canActivate(context: ExecutionContext): Promise<boolean> {
-    const isPublic = this.reflector.getAllAndOverride(PublicAccess, [
-      context.getHandler(),
-      context.getClass(),
-    ])
+    if (this.sessionVerifier.isPublic(context)) return true
 
-    if (isPublic) return true
-
-    const { request, response } = this.extractDataFromContext(context)
-    const verifySessionOptions = this.getVerifySessionOptions(context)
-
-    const session = await getSession(request, response, verifySessionOptions)
-
-    request.session = session
-    return true
-  }
-
-  private extractDataFromContext(context: ExecutionContext) {
-    if (this.customCtxDataExtractor) {
-      return this.customCtxDataExtractor(context)
-    }
-    const ctx = context.switchToHttp()
-    const request = ctx.getRequest()
-    const response = ctx.getResponse()
-
-    return { request, response }
-  }
-
-  private getVerifySessionOptions(
-    context: ExecutionContext,
-  ): VerifySessionOptions | undefined {
-    const verifySessionDecoratorOptions = this.reflector.get(
-      VerifySession,
-      context.getHandler(),
-    )
-
-    const {
-      roles,
-      permissions,
-      requireEmailVerification,
-      requireMFA,
-      options: verifySessionOptions,
-    } = verifySessionDecoratorOptions || {}
-    const extraClaimValidators: SessionClaimValidator[] = []
-    const validatorsToRemove: string[] = []
-
-    if (roles) {
-      extraClaimValidators.push(
-        UserRoles.UserRoleClaim.validators.includesAll(roles),
-      )
-    }
-
-    if (permissions) {
-      extraClaimValidators.push(
-        UserRoles.PermissionClaim.validators.includesAll(permissions),
-      )
-    }
-
-    if (requireEmailVerification) {
-      extraClaimValidators.push(EmailVerificationClaim.validators.isVerified())
-    } else if (requireEmailVerification === false) {
-      validatorsToRemove.push(EmailVerificationClaim.key)
-    }
-
-    if (requireMFA) {
-      extraClaimValidators.push(
-        MultiFactorAuthClaim.validators.hasCompletedMFARequirementsForAuth(),
-      )
-    } else if (requireMFA === false) {
-      validatorsToRemove.push(MultiFactorAuthClaim.key)
-    }
-
-    const overrideGlobalClaimValidators = async (
-      globalValidators: SessionClaimValidator[],
-    ) => {
-      let parsedValidators = [...globalValidators]
-
-      if (validatorsToRemove.length) {
-        parsedValidators = parsedValidators.filter(
-          (validator) => !validatorsToRemove.includes(validator.id),
-        )
-      }
-
-      return [...parsedValidators, ...extraClaimValidators]
-    }
-
-    if (!verifySessionOptions) {
-      return {
-        overrideGlobalClaimValidators,
-      }
-    }
-
-    if (verifySessionOptions.overrideGlobalClaimValidators) {
-      return {
-        overrideGlobalClaimValidators: async (
-          globalValidators,
-          session,
-          userContext,
-        ) => {
-          const baseValidators: SessionClaimValidator[] =
-            await verifySessionOptions.overrideGlobalClaimValidators(
-              globalValidators,
-              session,
-              userContext,
-            )
-          return overrideGlobalClaimValidators(baseValidators)
-        },
-      }
-    }
-
-    return {
-      ...verifySessionOptions,
-      overrideGlobalClaimValidators,
-    }
+    return this.sessionVerifier.verifySession(context)
   }
 }

--- a/src/supertokens-session.verifier.ts
+++ b/src/supertokens-session.verifier.ts
@@ -1,0 +1,141 @@
+import { ExecutionContext, Injectable, Optional } from '@nestjs/common'
+import { Reflector } from '@nestjs/core'
+import { EmailVerificationClaim } from 'supertokens-node/recipe/emailverification'
+import { MultiFactorAuthClaim } from 'supertokens-node/recipe/multifactorauth'
+import {
+  getSession,
+  SessionClaimValidator,
+  VerifySessionOptions,
+} from 'supertokens-node/recipe/session'
+import UserRoles from 'supertokens-node/recipe/userroles'
+import { PublicAccess, VerifySession } from './decorators'
+import { ContextDataExtractor } from './supertokens.types'
+
+@Injectable()
+export class SuperTokensSessionVerifier {
+  private readonly reflector: Reflector
+
+  constructor(
+    @Optional() private readonly customCtxDataExtractor?: ContextDataExtractor,
+  ) {
+    this.reflector = new Reflector()
+  }
+
+  public isPublic(context: ExecutionContext): boolean {
+    return Boolean(
+      this.reflector.getAllAndOverride(PublicAccess, [
+        context.getHandler(),
+        context.getClass(),
+      ]),
+    )
+  }
+
+  public async verifySession(context: ExecutionContext): Promise<boolean> {
+    const { request, response } = this.extractDataFromContext(context)
+    const verifySessionOptions = this.getVerifySessionOptions(context)
+
+    const session = await getSession(request, response, verifySessionOptions)
+
+    request.session = session
+    return true
+  }
+
+  public extractDataFromContext(context: ExecutionContext) {
+    if (this.customCtxDataExtractor) {
+      return this.customCtxDataExtractor(context)
+    }
+    const ctx = context.switchToHttp()
+    const request = ctx.getRequest()
+    const response = ctx.getResponse()
+
+    return { request, response }
+  }
+
+  public getVerifySessionOptions(
+    context: ExecutionContext,
+  ): VerifySessionOptions | undefined {
+    const verifySessionDecoratorOptions = this.reflector.get(
+      VerifySession,
+      context.getHandler(),
+    )
+
+    const {
+      roles,
+      permissions,
+      requireEmailVerification,
+      requireMFA,
+      options: verifySessionOptions,
+    } = verifySessionDecoratorOptions || {}
+    const extraClaimValidators: SessionClaimValidator[] = []
+    const validatorsToRemove: string[] = []
+
+    if (roles) {
+      extraClaimValidators.push(
+        UserRoles.UserRoleClaim.validators.includesAll(roles),
+      )
+    }
+
+    if (permissions) {
+      extraClaimValidators.push(
+        UserRoles.PermissionClaim.validators.includesAll(permissions),
+      )
+    }
+
+    if (requireEmailVerification) {
+      extraClaimValidators.push(EmailVerificationClaim.validators.isVerified())
+    } else if (requireEmailVerification === false) {
+      validatorsToRemove.push(EmailVerificationClaim.key)
+    }
+
+    if (requireMFA) {
+      extraClaimValidators.push(
+        MultiFactorAuthClaim.validators.hasCompletedMFARequirementsForAuth(),
+      )
+    } else if (requireMFA === false) {
+      validatorsToRemove.push(MultiFactorAuthClaim.key)
+    }
+
+    const overrideGlobalClaimValidators = async (
+      globalValidators: SessionClaimValidator[],
+    ) => {
+      let parsedValidators = [...globalValidators]
+
+      if (validatorsToRemove.length) {
+        parsedValidators = parsedValidators.filter(
+          (validator) => !validatorsToRemove.includes(validator.id),
+        )
+      }
+
+      return [...parsedValidators, ...extraClaimValidators]
+    }
+
+    if (!verifySessionOptions) {
+      return {
+        overrideGlobalClaimValidators,
+      }
+    }
+
+    if (verifySessionOptions.overrideGlobalClaimValidators) {
+      return {
+        overrideGlobalClaimValidators: async (
+          globalValidators,
+          session,
+          userContext,
+        ) => {
+          const baseValidators: SessionClaimValidator[] =
+            await verifySessionOptions.overrideGlobalClaimValidators(
+              globalValidators,
+              session,
+              userContext,
+            )
+          return overrideGlobalClaimValidators(baseValidators)
+        },
+      }
+    }
+
+    return {
+      ...verifySessionOptions,
+      overrideGlobalClaimValidators,
+    }
+  }
+}

--- a/src/supertokens.module.ts
+++ b/src/supertokens.module.ts
@@ -4,21 +4,22 @@ import {
   Provider,
   DynamicModule,
   Inject,
-} from "@nestjs/common"
+} from '@nestjs/common'
 
-import { SuperTokensExpressAuthMiddleware } from "./supertokens-express.middleware"
-import { SUPERTOKENS_MODULE_OPTIONS } from "./supertokens.constants"
-import { SuperTokensService } from "./supertokens.service"
+import { SuperTokensExpressAuthMiddleware } from './supertokens-express.middleware'
+import { SUPERTOKENS_MODULE_OPTIONS } from './supertokens.constants'
+import { SuperTokensService } from './supertokens.service'
+import { SuperTokensSessionVerifier } from './supertokens-session.verifier'
 
 import {
   SuperTokensModuleOptions,
   SuperTokensModuleOptionsFactory,
   SuperTokensModuleAsyncOptions,
-} from "./supertokens.types"
+} from './supertokens.types'
 
 @Module({
-  providers: [SuperTokensService],
-  exports: [],
+  providers: [SuperTokensService, SuperTokensSessionVerifier],
+  exports: [SuperTokensSessionVerifier],
   controllers: [],
 })
 export class SuperTokensModule {
@@ -28,8 +29,8 @@ export class SuperTokensModule {
   ) {}
 
   configure(consumer: MiddlewareConsumer) {
-    if (this.options.framework !== "express") return
-    consumer.apply(SuperTokensExpressAuthMiddleware).forRoutes("*")
+    if (this.options.framework !== 'express') return
+    consumer.apply(SuperTokensExpressAuthMiddleware).forRoutes('*')
   }
 
   static forRoot(
@@ -45,7 +46,9 @@ export class SuperTokensModule {
           provide: SUPERTOKENS_MODULE_OPTIONS,
         },
         SuperTokensService,
+        SuperTokensSessionVerifier,
       ],
+      exports: [SuperTokensSessionVerifier],
     }
   }
 
@@ -56,7 +59,11 @@ export class SuperTokensModule {
       module: SuperTokensModule,
       global,
       imports: options.imports || [],
-      providers: [...this.createAsyncProviders(options)],
+      providers: [
+        ...this.createAsyncProviders(options),
+        SuperTokensSessionVerifier,
+      ],
+      exports: [SuperTokensSessionVerifier],
     }
   }
 
@@ -76,7 +83,7 @@ export class SuperTokensModule {
       ]
     }
 
-    throw new Error("Invalid configuration options")
+    throw new Error('Invalid configuration options')
   }
 
   private static createAsyncOptionsProvider(
@@ -97,6 +104,6 @@ export class SuperTokensModule {
         inject: [options.useExisting],
       }
     }
-    throw new Error("Invalid configuration options")
+    throw new Error('Invalid configuration options')
   }
 }


### PR DESCRIPTION
Expose SuperTokensSessionVerifier so custom guards can reuse the same session validation path as SuperTokensAuthGuard without duplicating `VerifySession` logic.

This is needed for composed auth flows, such as accepting either an API key or a bearer token on the same route. Those routes must bypass the global guard for API key requests, but still need the exact SuperTokens session validation semantics when falling back to bearer tokens.

```ts
@Injectable()
class AuthorizesGuard implements CanActivate {
  constructor(
    private readonly apiKeysService: ApiKeysService,
    private readonly sessionVerifier: SuperTokensSessionVerifier,
  ) {}

  async canActivate(context: ExecutionContext) {
    const apiKey = getApiKey(context);

    if (apiKey) {
      await checkApiKey(apiKey, ["custom-permission"]);
      return true;
    }

    return this.sessionVerifier.verifySession(context);
  }
}
```